### PR TITLE
Fix video link saving issue

### DIFF
--- a/lib/screens/add_video_screen.dart
+++ b/lib/screens/add_video_screen.dart
@@ -68,7 +68,9 @@ class _AddVideoScreenState extends State<AddVideoScreen> {
     final platform = _urlService.detectPlatform(url);
     setState(() {
       _selectedPlatform = platform;
-    }); // Si es YouTube, trata de obtener la miniatura y el título
+    });
+
+    // Si es YouTube, trata de obtener la miniatura y el título
     if (platform == PlatformType.youtube) {
       final youtubeInfo = await _urlService.getYouTubeInfo(url);
       if (youtubeInfo != null) {
@@ -85,17 +87,31 @@ class _AddVideoScreenState extends State<AddVideoScreen> {
       }
     } else {
       // Para otras plataformas
-      setState(() {
-        _isUrlValid = true;
+      final extractedTitle = _urlService.extractTitleFromUrl(url, platform);
+      if (extractedTitle != null) {
+        setState(() {
+          _titleController.text = extractedTitle;
+        });
+      }
 
-        // Intentar extraer un título de la URL si el campo está vacío
-        if (_titleController.text.isEmpty) {
-          final extractedTitle = _urlService.extractTitleFromUrl(url, platform);
-          if (extractedTitle != null) {
-            _titleController.text = extractedTitle;
+      // Lógica para obtener miniatura y título para otras plataformas
+      final otherPlatformInfo = await _urlService.getOtherPlatformInfo(url, platform);
+      if (otherPlatformInfo != null) {
+        setState(() {
+          _thumbnailUrl = otherPlatformInfo['thumbnailUrl'] ?? '';
+          _isUrlValid = true;
+
+          // Si hay un título disponible y el campo está vacío, lo completamos automáticamente
+          if (otherPlatformInfo['title']?.isNotEmpty == true &&
+              _titleController.text.isEmpty) {
+            _titleController.text = otherPlatformInfo['title'] ?? '';
           }
-        }
-      });
+        });
+      } else {
+        setState(() {
+          _isUrlValid = true;
+        });
+      }
     }
 
     setState(() {

--- a/lib/screens/share_receiver_screen.dart
+++ b/lib/screens/share_receiver_screen.dart
@@ -27,6 +27,7 @@ class _ShareReceiverScreenState extends State<ShareReceiverScreen> {
   Folder? _selectedFolder;
   bool _isLoading = true;
   bool _isSaving = false;
+  bool _isUrlValid = false;
 
   @override
   void initState() {
@@ -73,9 +74,11 @@ class _ShareReceiverScreenState extends State<ShareReceiverScreen> {
           } else {
             _titleController.text = 'Video de YouTube';
           }
+          _isUrlValid = true;
         });
       } else {
         _titleController.text = 'Video de YouTube';
+        _isUrlValid = true;
       }
     } else {
       // Para otras plataformas
@@ -101,6 +104,25 @@ class _ShareReceiverScreenState extends State<ShareReceiverScreen> {
             _titleController.text = 'Contenido compartido';
             break;
         }
+      }
+
+      // Lógica para obtener miniatura y título para otras plataformas
+      final otherPlatformInfo = await _urlService.getOtherPlatformInfo(url, platform);
+      if (otherPlatformInfo != null) {
+        setState(() {
+          _thumbnailUrl = otherPlatformInfo['thumbnailUrl'] ?? '';
+          _isUrlValid = true;
+
+          // Si hay un título disponible y el campo está vacío, lo completamos automáticamente
+          if (otherPlatformInfo['title']?.isNotEmpty == true &&
+              _titleController.text.isEmpty) {
+            _titleController.text = otherPlatformInfo['title'] ?? '';
+          }
+        });
+      } else {
+        setState(() {
+          _isUrlValid = true;
+        });
       }
     }
   }
@@ -360,7 +382,7 @@ class _ShareReceiverScreenState extends State<ShareReceiverScreen> {
                     Expanded(
                       flex: 2,
                       child: ElevatedButton(
-                        onPressed: _isSaving || _folders.isEmpty
+                        onPressed: _isSaving || _folders.isEmpty || !_isUrlValid
                             ? null
                             : _saveVideo,
                         child: _isSaving
@@ -381,5 +403,3 @@ class _ShareReceiverScreenState extends State<ShareReceiverScreen> {
     );
   }
 }
-
-// Fin de la clase


### PR DESCRIPTION
Update functions to obtain data such as title, thumbnail, and platform from URLs and enable the save button when data is valid.

* **lib/screens/add_video_screen.dart**
  - Update `_validateUrl` method to handle other platforms.
  - Add logic to fetch title and thumbnail for other platforms.
  - Enable save button when URL is valid.

* **lib/services/url_service.dart**
  - Add methods to fetch title and thumbnail for other platforms.
  - Update `extractTitleFromUrl` to handle more platforms.

* **lib/screens/share_receiver_screen.dart**
  - Update `_processSharedUrl` to handle other platforms.
  - Add logic to fetch title and thumbnail for other platforms.
  - Enable save button when URL is valid.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/angelaramiz/myapp/pull/1?shareId=0a944c4d-3863-4bb9-a82e-cd002d508448).